### PR TITLE
Fix/sidebar input deselection

### DIFF
--- a/app/calculate/sweep/page.tsx
+++ b/app/calculate/sweep/page.tsx
@@ -969,47 +969,51 @@ function SweepPage() {
           }}
         >Add</button>
       </Modal>
-      <SideBarContent>
-        <SelectInput
-          type="segmented"
-          label=""
-          options={["Configure Sweep", "Configure Graph"]}
-          value={sidebarTab}
-          onChange={setSidebarTab}
-        />
-        {sidebarTab === "Configure Sweep" && (
-          <SweepConfig
-            config={sweepConfig}
-            setConfig={setSweepConfig}
-            sweep={sweepConfig.isTwoDimensional ? run2DSweep : run1DSweep}
-          />
-        )}
-        {sidebarTab === "Configure Graph" && !sweepConfig.isTwoDimensional && (
-          (!sweepData1DErr) ?
-            <GraphConfig1D
-              config={oneDGraphConfig}
-              colours={sweepData1D ? sweepData1D.colours : { line: [], noise: [] }}
-              setConfig={setOneDGraphConfig}
-            /> : <p className="text-center justify-center cursor-pointer" onClick={run1DSweep}>
-              <span className="text-lg">Run a 1D Sweep to View Configuration Options</span>
-              <br />
-              <span className="text-md text-gray-500">Click to run the sweep</span>
-            </p>
-        )}
-        {sidebarTab === "Configure Graph" && sweepConfig.isTwoDimensional && (
-          (!sweepData2DErr) ?
-            <GraphConfig2D
-              configs={twoDGraphConfig}
-              setConfigs={setTwoDGraphConfig}
-              modal={{ modal: add2DGraphModal, setModal: setAdd2DGraphModal }}
-            /> : <p className="text-center justify-center cursor-pointer" onClick={run2DSweep}>
-              <span className="text-lg">Run a 2D Sweep to View Configuration Options</span>
-              <br />
-              <span className="text-md text-gray-500">Click to run the sweep</span>
-            </p>
+      {/* Generate the Sidebar element */}
+      {SideBarContent({
+        children: (
+          <>
+            <SelectInput
+              type="segmented"
+              label=""
+              options={["Configure Sweep", "Configure Graph"]}
+              value={sidebarTab}
+              onChange={setSidebarTab}
+            />
+            {sidebarTab === "Configure Sweep" && (
+              <SweepConfig
+                config={sweepConfig}
+                setConfig={setSweepConfig}
+                sweep={sweepConfig.isTwoDimensional ? run2DSweep : run1DSweep}
+              />
+            )}
+            {sidebarTab === "Configure Graph" && !sweepConfig.isTwoDimensional && (
+              (!sweepData1DErr) ?
+                <GraphConfig1D
+                  config={oneDGraphConfig}
+                  colours={sweepData1D ? sweepData1D.colours : { line: [], noise: [] }}
+                  setConfig={setOneDGraphConfig}
+                /> : <p className="text-center justify-center cursor-pointer" onClick={run1DSweep}>
+                  <span className="text-lg">Run a 1D Sweep to View Configuration Options</span>
+                  <br />
+                  <span className="text-md text-gray-500">Click to run the sweep</span>
+                </p>
+            )}
+            {sidebarTab === "Configure Graph" && sweepConfig.isTwoDimensional && (
+              (!sweepData2DErr) ?
+                <GraphConfig2D
+                  configs={twoDGraphConfig}
+                  setConfigs={setTwoDGraphConfig}
+                  modal={{ modal: add2DGraphModal, setModal: setAdd2DGraphModal }}
+                /> : <p className="text-center justify-center cursor-pointer" onClick={run2DSweep}>
+                  <span className="text-lg">Run a 2D Sweep to View Configuration Options</span>
+                  <br />
+                  <span className="text-md text-gray-500">Click to run the sweep</span>
+                </p>
 
-        )}
-      </SideBarContent>
+            )}
+          </>)
+      })}
       {!sweepConfig.isTwoDimensional && sweepData1DErr && sweepData1DErr !== "loading" && (
         <div className="flex flex-col justify-around items-center w-full h-full">
           <p>


### PR DESCRIPTION
Sidebar component was being recreated every re-render, which was causing it to lose the active input selection on every re-render, hindering user input.

By switching to calling it as a function instead of a component, it is no longer recreated upon each re-render, fixing the issue.

Caution is advised in regards to use of state variables in combination with this method.

For reference regarding the difference between using a functional component as a component versus a function, see: 
https://dev.to/igor_bykov/react-calling-functional-components-as-functions-1d3l