### PR TITLE
fix one dimensional graphs not rendering all x-axis labels

### DIFF
--- a/components/graphs/lineGraph.tsx
+++ b/components/graphs/lineGraph.tsx
@@ -71,11 +71,24 @@ function getDistances(index: number, labels: string[], xMax: number): [number, n
 
 // eslint-disable-next-line max-lines-per-function
 function generateGraph({ data, fullData, width, height, xOffsetPer, yOffsetPer, linear, xLabel, yLabel, type, graphID, toSVG }: GraphDefinition): { graph: React.JSX.Element, warnings: string[] } {
+
+    const labelFontSize = Math.max(height / 45, 10);
+    const tickLabelFontSize = Math.max(height / 50, 10);
+
+    const topOffsetDivisor = (toSVG) ? 6 : 3;
+    const leftOffsetDivisor = (toSVG) ? 3 : 1.3;
+
+    const axisLabelHeight = labelFontSize * 2;
+
     // calculate bounds
-    const xOffset = width * xOffsetPer;
-    const yOffset = height * yOffsetPer;
-    const xMax = width - xOffset;
-    const yMax = height - yOffset;
+    const gWidth = width - axisLabelHeight;
+    const gHeight = height - axisLabelHeight;
+
+    const xOffset = gWidth * xOffsetPer;
+    const yOffset = gHeight * yOffsetPer;
+
+    const xMax = gWidth - xOffset;
+    const yMax = gHeight - yOffset;
 
     // generate scales
     const xScale = (linear[0]) ? scaleLinear({
@@ -230,14 +243,10 @@ function generateGraph({ data, fullData, width, height, xOffsetPer, yOffsetPer, 
         return (xOffset / 2) + (xPos);
     }
 
-    const labelFontSize = Math.max(height / 45, 10);
-    const tickLabelFontSize = Math.max(height / 50, 10);
 
-    const topOffsetDivisor = (toSVG) ? 6 : 3;
-    const leftOffsetDivisor = (toSVG) ? 3 : 1.3;
 
     const graph = (<svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} key={"group-" + type + '-' + graphID}>
-        <Group top={yOffset / topOffsetDivisor} left={xOffset / leftOffsetDivisor} >
+        <Group top={yOffset / topOffsetDivisor} left={(xOffset / leftOffsetDivisor) + axisLabelHeight} >
             <DualVerticalAxis
                 directionality={"left"}
                 thirdAxis={false}
@@ -259,7 +268,6 @@ function generateGraph({ data, fullData, width, height, xOffsetPer, yOffsetPer, 
                 scale={xScale}
                 label={xLabel}
                 labelProps={{ fontSize: labelFontSize, textAnchor: 'middle' }}
-                labelOffset={15}
                 numTicks={5}
                 tickLabelProps={{ fontSize: tickLabelFontSize }}
                 top={yMax}
@@ -281,7 +289,7 @@ function generateGraph({ data, fullData, width, height, xOffsetPer, yOffsetPer, 
         {toSVG && cLines.map((c, i) =>
             <Group
                 top={generateTopPos(i, lineLabelsFull)}
-                left={generateLeftPos(i, lineLabelsFull)}
+                left={generateLeftPos(i, lineLabelsFull) + axisLabelHeight}
                 key={"legend-" + type + '-' + graphID + '-' + i}
             >
                 <rect

--- a/components/oneDSweepGraphs.tsx
+++ b/components/oneDSweepGraphs.tsx
@@ -106,9 +106,6 @@ export default function OneDSweepGraphs({ sweepData, oneDGraphConfig, lineSignal
                         setModal={setModal}
                         modalDimensions={dimensions}
                     />}
-                    {oneDGraphConfig.showColumns[1] && oneDGraphConfig.showColumns[0] &&
-                        <svg width={noiseWidth} height={rowHeight}></svg>
-                    }
                 </div>
             )}
         </div>


### PR DESCRIPTION
Adjusted size and bounding of 1D sweep graphs such that the x and y axis labels will show under most conditions.
Exception is when screen is very small on the associated dimension, squashing label.