### PR TITLE
Fix/1D x axis labels

### DIFF
--- a/app/calculate/sweep/page.tsx
+++ b/app/calculate/sweep/page.tsx
@@ -1039,6 +1039,7 @@ export default function SweepPage() {
           noiseTypes={noiseTypes}
           filterLines={filterLines}
           setModal={setModal1D}
+          sweepVariable={sweepConfig.stageID}
         />
       }
       {!sweepData1DErr && !sweepConfig.isTwoDimensional && modal1D != null &&

--- a/components/oneDSweepGraphs.tsx
+++ b/components/oneDSweepGraphs.tsx
@@ -12,11 +12,12 @@ type OneDGraphsProps = {
     lineSignalTypes: ("Drive" | "Flux" | "Output")[],
     noiseTypes: string[],
     filterLines: (data: SweepData[], graphID: number, lineSignalTypes: ("Drive" | "Flux" | "Output")[], selected: boolean[][][], showTotalLines: boolean[], nSelected?: boolean[]) => SweepData[],
-    setModal: React.Dispatch<React.SetStateAction<React.JSX.Element | null>>
+    setModal: React.Dispatch<React.SetStateAction<React.JSX.Element | null>>,
+    sweepVariable: string
 }
 
 // eslint-disable-next-line max-lines-per-function
-export default function OneDSweepGraphs({ sweepData, oneDGraphConfig, lineSignalTypes, noiseTypes, filterLines, setModal }: OneDGraphsProps): ReactNode {
+export default function OneDSweepGraphs({ sweepData, oneDGraphConfig, lineSignalTypes, noiseTypes, filterLines, setModal, sweepVariable }: OneDGraphsProps): ReactNode {
     const [ref, dimensions] = useDimensions<HTMLDivElement>();
 
     const fridge = useFridge();
@@ -53,7 +54,7 @@ export default function OneDSweepGraphs({ sweepData, oneDGraphConfig, lineSignal
                         stage: s.stage,
                         graphID: s.id,
                         type: 'heatLoad',
-                        xLabel: "Attenuation on " + s.stage,
+                        xLabel: "Attenuation on " + sweepVariable,
                         yLabel: "Heat Load",
                         linear: oneDGraphConfig.scaleLin,
                         setModal: setModal,
@@ -65,7 +66,7 @@ export default function OneDSweepGraphs({ sweepData, oneDGraphConfig, lineSignal
                         stage: s.stage,
                         graphID: s.id,
                         type: 'temperature',
-                        xLabel: "Attenuation on " + s.stage,
+                        xLabel: "Attenuation on " + sweepVariable,
                         yLabel: "Temperature",
                         linear: oneDGraphConfig.scaleLin,
                         setModal: setModal,
@@ -84,7 +85,7 @@ export default function OneDSweepGraphs({ sweepData, oneDGraphConfig, lineSignal
                         stage={'Noise'}
                         graphID={fridge.stages.length}
                         type={'heatLoad'}
-                        xLabel={"Attenuation"}
+                        xLabel={"Attenuation on " + sweepVariable}
                         yLabel={"Noise " + noiseTypes[oneDGraphConfig.noiseType]}
                         height={rowHeight}
                         width={noiseWidth}
@@ -98,7 +99,7 @@ export default function OneDSweepGraphs({ sweepData, oneDGraphConfig, lineSignal
                         stage={'Noise'}
                         graphID={fridge.stages.length}
                         type={'heatLoad'}
-                        xLabel={"Attenuation"}
+                        xLabel={"Attenuation on " + sweepVariable}
                         yLabel={"Noise " + noiseTypes[oneDGraphConfig.noiseType]}
                         height={rowHeight}
                         width={noiseWidth}


### PR DESCRIPTION
Adjusted the x-axis labels of 1D sweep graphs to display 'Attenuation on <sweep_variable>' rather than 'Attenuation on <stage_name>'.