### PR TITLE
Fix/temperature bounding limiting heatload display in 2D sweep

### DIFF
--- a/components/pyodide/fridge.ts
+++ b/components/pyodide/fridge.ts
@@ -634,12 +634,6 @@ export function sweepModel2D(model: CryoModelInterface, fridge: FridgeConfig, li
                     // calculate temperature estimate
                     t_est = model.applyBoundedTStages(totalTemp);
 
-                    // check for NaN values in temperature estimates
-                    if (t_est.some((t) => isNaN(t))) {
-                        tempOutOfBounds = true;
-                        break;
-                    }
-
                     // collate data to matrix, applying cooling power
                     const load_matrix: number[][] = data.map((d) =>
                         stages.map((stage, s) => (d.output[stage] / cooling_power[s]))
@@ -650,6 +644,12 @@ export function sweepModel2D(model: CryoModelInterface, fridge: FridgeConfig, li
 
                     // update to current load matrix for next loop
                     load_matrix_0 = load_matrix.map((l) => l.map((s) => s));
+
+                    // check for NaN values in temperature estimates
+                    if (t_est.some((t) => isNaN(t))) {
+                        tempOutOfBounds = true;
+                        break;
+                    }
                 }
 
                 //noise data


### PR DESCRIPTION
The placement of my NaN check and break statement was meaning that heat load values were not being calculated if temperature bounds were exceeded, which was limiting the points on the heat graph unnecessarily.
Fixed by simply moving the NaN check for temperatures and the break statement to the end of the loop, after the heat load values have been calculated for that iteration of the loop.